### PR TITLE
Set serialized name for all fields in modelclasses

### DIFF
--- a/castle/src/main/java/io/castle/android/api/model/Context.java
+++ b/castle/src/main/java/io/castle/android/api/model/Context.java
@@ -1,5 +1,7 @@
 package io.castle.android.api.model;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -10,12 +12,19 @@ import io.castle.android.Castle;
  */
 
 public class Context {
+    @SerializedName("device")
     Device device;
+    @SerializedName("os")
     OS os;
+    @SerializedName("library")
     LibraryVersion library;
+    @SerializedName("timezone")
     String timezone;
+    @SerializedName("locale")
     String locale;
+    @SerializedName("screen")
     Screen screen;
+    @SerializedName("network")
     Network network;
 
     private Context(android.content.Context context) {

--- a/castle/src/main/java/io/castle/android/api/model/Device.java
+++ b/castle/src/main/java/io/castle/android/api/model/Device.java
@@ -2,6 +2,8 @@ package io.castle.android.api.model;
 
 import android.os.Build;
 
+import com.google.gson.annotations.SerializedName;
+
 import io.castle.android.Castle;
 
 /**
@@ -9,10 +11,15 @@ import io.castle.android.Castle;
  */
 
 class Device {
+    @SerializedName("id")
     private String id;
+    @SerializedName("manufacturer")
     private String manufacturer;
+    @SerializedName("model")
     private String model;
+    @SerializedName("name")
     private String name;
+    @SerializedName("type")
     private String type;
 
     public static Device create() {

--- a/castle/src/main/java/io/castle/android/api/model/Error.java
+++ b/castle/src/main/java/io/castle/android/api/model/Error.java
@@ -1,11 +1,15 @@
 package io.castle.android.api.model;
 
+import com.google.gson.annotations.SerializedName;
+
 /**
  * Copyright (c) 2017 Castle
  */
 
 public class Error {
+    @SerializedName("message")
     String message;
+    @SerializedName("type")
     String type;
 
     public String getMessage() {

--- a/castle/src/main/java/io/castle/android/api/model/Event.java
+++ b/castle/src/main/java/io/castle/android/api/model/Event.java
@@ -17,12 +17,15 @@ public class Event {
     public static String EVENT_TYPE_SCREEN = "screen";
     public static String EVENT_TYPE_IDENTIFY = "identify";
 
+    @SerializedName("context")
     Context context;
     @SerializedName(value="event", alternate={"name"})
     String event;
     @SerializedName(value="properties", alternate={"traits"})
     Map<String, String> properties;
+    @SerializedName("timestamp")
     String timestamp;
+    @SerializedName("type")
     String type;
     @SerializedName("user_id")
     String userId;

--- a/castle/src/main/java/io/castle/android/api/model/Network.java
+++ b/castle/src/main/java/io/castle/android/api/model/Network.java
@@ -7,6 +7,8 @@ import android.net.NetworkInfo;
 import android.support.v4.content.PermissionChecker;
 import android.telephony.TelephonyManager;
 
+import com.google.gson.annotations.SerializedName;
+
 import static android.Manifest.permission.ACCESS_NETWORK_STATE;
 import static android.content.Context.CONNECTIVITY_SERVICE;
 import static android.content.Context.TELEPHONY_SERVICE;
@@ -19,9 +21,13 @@ import static android.support.v4.content.PermissionChecker.PERMISSION_GRANTED;
  * Copyright (c) 2017 Castle
  */
 public class Network {
+    @SerializedName("bluetooth")
     Boolean bluetooth = null;
+    @SerializedName("carrier")
     String carrier = "unknown";
+    @SerializedName("cellular")
     Boolean cellular = null;
+    @SerializedName("wifi")
     Boolean wifi = null;
 
     @SuppressLint("MissingPermission")

--- a/castle/src/main/java/io/castle/android/api/model/Screen.java
+++ b/castle/src/main/java/io/castle/android/api/model/Screen.java
@@ -4,13 +4,18 @@ import android.content.Context;
 import android.util.DisplayMetrics;
 import android.view.WindowManager;
 
+import com.google.gson.annotations.SerializedName;
+
 
 /**
  * Copyright (c) 2017 Castle
  */
 public class Screen {
+    @SerializedName("width")
     int width;
+    @SerializedName("height")
     int height;
+    @SerializedName("density")
     float density;
 
     private Screen(Context context) {

--- a/castle/src/main/java/io/castle/android/api/model/Version.java
+++ b/castle/src/main/java/io/castle/android/api/model/Version.java
@@ -2,11 +2,15 @@ package io.castle.android.api.model;
 
 import android.os.Build;
 
+import com.google.gson.annotations.SerializedName;
+
 /**
  * Copyright (c) 2017 Castle
  */
 public abstract class Version {
+    @SerializedName("version")
     protected String version;
+    @SerializedName("name")
     protected String name;
 
     protected Version(String name, String version) {


### PR DESCRIPTION
Use SerializedName annotation for model fields to make sure that serialization/deserialization always is correct