### PR TITLE
Fix/remove unnecessary manifest settings

### DIFF
--- a/castle/src/main/AndroidManifest.xml
+++ b/castle/src/main/AndroidManifest.xml
@@ -3,11 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <application android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-
+    <application>
         <activity android:name=".TestActivity"/>
     </application>
 

--- a/castle/src/main/AndroidManifest.xml
+++ b/castle/src/main/AndroidManifest.xml
@@ -7,8 +7,6 @@
         android:label="@string/app_name"
         android:supportsRtl="true">
 
-        <meta-data android:name="castle_publishable_key"
-            android:value="@string/castle_publishable_key"/>
 
         <activity android:name=".TestActivity"/>
     </application>

--- a/castle/src/main/res/values/strings.xml
+++ b/castle/src/main/res/values/strings.xml
@@ -1,4 +1,0 @@
-<resources>
-    <string name="app_name">Castle</string>
-    <string name="castle_publishable_key">pk_xxxxxxxxxx</string>
-</resources>


### PR DESCRIPTION
Remove unused and unnecessary settings from AndroidManifest.xml. This should be set by the implementing application.