### PR TITLE
Add secure mode support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'org.jacoco:org.jacoco.core:0.8.3'
 

--- a/castle/bintray.gradle
+++ b/castle/bintray.gradle
@@ -1,8 +1,13 @@
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.dcendents.android-maven'
 
-version = VERSION_NAME
-group = GROUP
+version = '1.0.3'
+group = 'io.castle.android'
+
+def POM_ARTIFACT_ID = 'castle'
+def POM_DESCRIPTION = 'Android client library for Castle'
+def POM_URL = 'https://github.com/castle/castle-android'
+def POM_SCM_CONNECTION = 'scm:git:git://github.com/castle/castle-android.git'
 
 def getRepositoryUsername() {
     return hasProperty('BINTRAY_USER') ? BINTRAY_USER : ""
@@ -25,7 +30,7 @@ bintray {
         name = POM_ARTIFACT_ID
         desc = POM_DESCRIPTION
         websiteUrl = POM_URL
-        vcsUrl = VCS_URL
+        vcsUrl = POM_URL
         publish = true
         publicDownloadNumbers = true
         version {
@@ -42,33 +47,33 @@ bintray {
 install {
     repositories.mavenInstaller {
         pom.project {
-            name POM_NAME
+            name 'castle-android'
             description POM_DESCRIPTION
             url POM_URL
 
-            packaging POM_PACKAGING
-            groupId GROUP
+            packaging 'aar'
+            groupId group
             artifactId POM_ARTIFACT_ID
-            version VERSION_NAME
+            version version
 
             licenses {
                 license {
-                    name POM_LICENCE_NAME
-                    url POM_LICENCE_URL
-                    distribution POM_LICENCE_DIST
+                    name 'The MIT License'
+                    url 'https://opensource.org/licenses/MIT'
+                    distribution 'repo'
                 }
             }
 
             scm {
-                url POM_SCM_URL
+                url POM_URL
                 connection POM_SCM_CONNECTION
-                developerConnection POM_SCM_DEV_CONNECTION
+                developerConnection POM_SCM_CONNECTION
             }
 
             developers {
                 developer {
-                    id POM_DEVELOPER_ID
-                    name POM_DEVELOPER_NAME
+                    id 'castle'
+                    name 'Castle Intelligence, Inc.'
                 }
             }
         }

--- a/castle/bintray.gradle
+++ b/castle/bintray.gradle
@@ -1,9 +1,8 @@
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.dcendents.android-maven'
 
-version = '1.0.3'
-group = 'io.castle.android'
-
+def POM_VERSION = '1.0.3'
+def POM_GROUP_ID = 'io.castle.android'
 def POM_ARTIFACT_ID = 'castle'
 def POM_DESCRIPTION = 'Android client library for Castle'
 def POM_URL = 'https://github.com/castle/castle-android'
@@ -20,6 +19,9 @@ def getRepositoryApiKey() {
 def getRepositoryPassword() {
     return hasProperty('BINTRAY_GPG_PASSWORD') ? BINTRAY_GPG_PASSWORD : ""
 }
+
+version = POM_VERSION
+group = POM_GROUP_ID
 
 bintray {
     user = getRepositoryUsername()
@@ -52,9 +54,9 @@ install {
             url POM_URL
 
             packaging 'aar'
-            groupId group
+            groupId POM_GROUP_ID
             artifactId POM_ARTIFACT_ID
-            version version
+            version POM_VERSION
 
             licenses {
                 license {

--- a/castle/build.gradle
+++ b/castle/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 28
         versionCode 1
-        versionName "1.0.3"
+        versionName VERSION_NAME
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/castle/build.gradle
+++ b/castle/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 28
         versionCode 1
-        versionName VERSION_NAME
+        versionName '1.0.3'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/castle/build.gradle
+++ b/castle/build.gradle
@@ -1,12 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'jacoco'
 
-ext {
-    PUBLISH_GROUP_ID = 'io.castle.android'
-    PUBLISH_ARTIFACT_ID = 'castle'
-    PUBLISH_VERSION = '1.0.3'
-}
-
 jacoco {
     toolVersion = '0.8.3'
 }
@@ -83,9 +77,6 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestUtil 'androidx.test:orchestrator:1.1.1'
 }
-
-// or use the remote copy to keep update with latest changes
-apply from: 'https://raw.githubusercontent.com/blundell/release-android-library/master/android-release-aar.gradle'
 
 if (!ciBuild) {
     apply from: 'bintray.gradle'

--- a/castle/src/main/java/io/castle/android/Castle.java
+++ b/castle/src/main/java/io/castle/android/Castle.java
@@ -11,7 +11,6 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-import android.util.Log;
 
 import java.io.IOException;
 import java.net.MalformedURLException;

--- a/castle/src/main/java/io/castle/android/Castle.java
+++ b/castle/src/main/java/io/castle/android/Castle.java
@@ -278,7 +278,7 @@ public class Castle {
         if (signature == null || signature.isEmpty()) {
             return;
         }
-        Castle.signature(signature);
+        Castle.userSignature(signature);
     }
 
     /**
@@ -286,7 +286,7 @@ public class Castle {
      * @return True if signature is set
      */
     public static boolean secureModeEnabled() {
-        return Castle.signature() != null;
+        return Castle.userSignature() != null;
     }
 
     /**
@@ -306,19 +306,19 @@ public class Castle {
     }
 
     /**
-     * Get the signature if set, otherwise returns null
+     * Get the user signature if set, otherwise returns null
      * @return signature
      */
-    public static String signature() {
-        return instance.storageHelper.getSignature();
+    public static String userSignature() {
+        return instance.storageHelper.getUserSignature();
     }
 
     /**
-     * Set the signature for secure mode
+     * Set the user signature for secure mode
      * @param signature The signature to be used for secure mode
      */
-    public static void signature(String signature) {
-        instance.storageHelper.setSignature(signature);
+    public static void userSignature(String signature) {
+        instance.storageHelper.setUserSignature(signature);
     }
 
     /**

--- a/castle/src/main/java/io/castle/android/Castle.java
+++ b/castle/src/main/java/io/castle/android/Castle.java
@@ -193,18 +193,7 @@ public class Castle {
      * @param userId user id
      */
     public static void identify(String userId) {
-        if (userId == null || userId.isEmpty()) {
-            return;
-        }
-
-        // Log warning if identify is called without secure mode signature set.
-        if (!Castle.secureModeEnabled()) {
-            CastleLogger.w("Identify called without secure mode signature set. If secure mode is enabled in Castle and identify is called before secure, the identify event will be discarded.");
-        }
-
-        Castle.userId(userId);
-        track(new IdentifyEvent(userId));
-        flush();
+        identify(userId, new HashMap<>());
     }
 
     /**
@@ -216,6 +205,12 @@ public class Castle {
         if (userId == null || userId.isEmpty() || traits == null) {
             return;
         }
+
+        // Log warning if identify is called without secure mode signature set.
+        if (!Castle.secureModeEnabled()) {
+            CastleLogger.w("Identify called without secure mode signature set. If secure mode is enabled in Castle and identify is called before secure, the identify event will be discarded.");
+        }
+
         Castle.userId(userId);
         track(new IdentifyEvent(userId, traits));
         flush();

--- a/castle/src/main/java/io/castle/android/Castle.java
+++ b/castle/src/main/java/io/castle/android/Castle.java
@@ -32,7 +32,6 @@ public class Castle {
     private static Castle instance;
     private Application application;
     private String identifier;
-    private String signature;
     private CastleConfiguration configuration;
     private EventQueue eventQueue;
     private StorageHelper storageHelper;
@@ -310,15 +309,15 @@ public class Castle {
      * @return signature
      */
     public static String signature() {
-        return instance.signature;
+        return instance.storageHelper.getSignature();
     }
 
     /**
      * Set the signature for secure mode
      * @param signature The signature to be used for secure mode
      */
-    public static String signature(String signature) {
-        return instance.signature = signature;
+    public static void signature(String signature) {
+        instance.storageHelper.setSignature(signature);
     }
 
     /**

--- a/castle/src/main/java/io/castle/android/Castle.java
+++ b/castle/src/main/java/io/castle/android/Castle.java
@@ -32,6 +32,7 @@ public class Castle {
     private static Castle instance;
     private Application application;
     private String identifier;
+    private String signature;
     private CastleConfiguration configuration;
     private EventQueue eventQueue;
     private StorageHelper storageHelper;
@@ -270,6 +271,25 @@ public class Castle {
     }
 
     /**
+     * Set signature to use for Secure Mode
+     * @param signature Signature sent to Castle to verify secure mode
+     */
+    public static void secure(String signature) {
+        if (signature == null || signature.isEmpty()) {
+            return;
+        }
+        Castle.signature(signature);
+    }
+
+    /**
+     * Check if a signature is set and secure mode enabled
+     * @return True if signature is set
+     */
+    public static boolean secureModeEnabled() {
+        return Castle.signature() != null;
+    }
+
+    /**
      * Get configured publishable key
      * @return publishable key
      */
@@ -283,6 +303,22 @@ public class Castle {
      */
     public static String clientId() {
         return instance.identifier;
+    }
+
+    /**
+     * Get the signature if set, otherwise returns null
+     * @return signature
+     */
+    public static String signature() {
+        return instance.signature;
+    }
+
+    /**
+     * Set the signature for secure mode
+     * @param signature The signature to be used for secure mode
+     */
+    public static String signature(String signature) {
+        return instance.signature = signature;
     }
 
     /**

--- a/castle/src/main/java/io/castle/android/Castle.java
+++ b/castle/src/main/java/io/castle/android/Castle.java
@@ -237,6 +237,7 @@ public class Castle {
     public static void reset() {
         Castle.flush();
         Castle.userId(null);
+        Castle.userSignature(null);
     }
 
     /**

--- a/castle/src/main/java/io/castle/android/Castle.java
+++ b/castle/src/main/java/io/castle/android/Castle.java
@@ -219,7 +219,7 @@ public class Castle {
      * @param userId  user id
      */
     private static void userId(String userId) {
-        instance.storageHelper.setIdentity(userId);
+        instance.storageHelper.setUserId(userId);
     }
 
     /**
@@ -227,7 +227,7 @@ public class Castle {
      * @return user id
      */
     public static String userId() {
-        return instance.storageHelper.getIdentity();
+        return instance.storageHelper.getUserId();
     }
 
     /**

--- a/castle/src/main/java/io/castle/android/Castle.java
+++ b/castle/src/main/java/io/castle/android/Castle.java
@@ -11,6 +11,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.util.Log;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -195,6 +196,12 @@ public class Castle {
         if (userId == null || userId.isEmpty()) {
             return;
         }
+
+        // Log warning if identify is called without secure mode signature set.
+        if (!Castle.secureModeEnabled()) {
+            Log.w("Castle SDK", "Identify called without secure mode signature set. If secure mode is enabled in Castle and identify is called before secure, the identify event will be discarded.");
+        }
+
         Castle.userId(userId);
         track(new IdentifyEvent(userId));
         flush();

--- a/castle/src/main/java/io/castle/android/Castle.java
+++ b/castle/src/main/java/io/castle/android/Castle.java
@@ -199,7 +199,7 @@ public class Castle {
 
         // Log warning if identify is called without secure mode signature set.
         if (!Castle.secureModeEnabled()) {
-            Log.w("Castle SDK", "Identify called without secure mode signature set. If secure mode is enabled in Castle and identify is called before secure, the identify event will be discarded.");
+            CastleLogger.w("Identify called without secure mode signature set. If secure mode is enabled in Castle and identify is called before secure, the identify event will be discarded.");
         }
 
         Castle.userId(userId);

--- a/castle/src/main/java/io/castle/android/CastleLogger.java
+++ b/castle/src/main/java/io/castle/android/CastleLogger.java
@@ -30,6 +30,14 @@ public class CastleLogger {
     }
 
     /**
+     * Send an warning log message
+     * @param message Message to be logged
+     */
+    public static void w(String message) {
+        Log.e(TAG, message);
+    }
+
+    /**
      * Send an debug log message
      * @param message Message to be logged
      */

--- a/castle/src/main/java/io/castle/android/EventAdapter.java
+++ b/castle/src/main/java/io/castle/android/EventAdapter.java
@@ -2,8 +2,7 @@
  * Copyright (c) 2017 Castle
  */
 
-package io.castle.android.api;
-
+package io.castle.android;
 import com.google.gson.Gson;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -19,12 +18,13 @@ import io.castle.android.api.model.Event;
 import io.castle.android.api.model.IdentifyEvent;
 import io.castle.android.api.model.ScreenEvent;
 
-public class EventAdapter implements JsonSerializer<Event>, JsonDeserializer<Event> {
-    Gson gson = new Gson();
+class EventAdapter implements JsonSerializer<Event>, JsonDeserializer<Event> {
+
+    private static final Gson gson = new Gson();
 
     @Override
     public JsonElement serialize(Event src, Type typeOfSrc, JsonSerializationContext context) {
-        JsonObject jsonObject = (JsonObject) new Gson().toJsonTree(src, typeOfSrc);
+        JsonObject jsonObject = (JsonObject) gson.toJsonTree(src, typeOfSrc);
 
         // XXXAus: We should do this a better way.
         if (src instanceof IdentifyEvent) {
@@ -40,12 +40,19 @@ public class EventAdapter implements JsonSerializer<Event>, JsonDeserializer<Eve
 
     @Override
     public Event deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-        JsonObject jsonObject = json.getAsJsonObject();
-        if (jsonObject.get("type").getAsString().equals(Event.EVENT_TYPE_IDENTIFY)) {
-            typeOfT = IdentifyEvent.class;
-        } else if (jsonObject.get("type").getAsString().equals(Event.EVENT_TYPE_SCREEN)) {
-            typeOfT = ScreenEvent.class;
+        if (typeOfT.equals(Event.class)) {
+            String type = json.getAsJsonObject().get("type").getAsString();
+
+            switch (type) {
+                case Event.EVENT_TYPE_IDENTIFY:
+                    typeOfT = IdentifyEvent.class;
+                    break;
+                case Event.EVENT_TYPE_SCREEN:
+                    typeOfT = ScreenEvent.class;
+                    break;
+            }
         }
+
         return gson.fromJson(json, typeOfT);
     }
 }

--- a/castle/src/main/java/io/castle/android/StorageHelper.java
+++ b/castle/src/main/java/io/castle/android/StorageHelper.java
@@ -44,11 +44,11 @@ class StorageHelper {
         getPreferencesEditor().putString(DEVICE_ID_KEY, deviceId).commit();
     }
 
-    String getIdentity() {
+    String getUserId() {
         return getPreferences().getString(USER_ID_KEY, null);
     }
 
-    void setIdentity(String userId) {
+    void setUserId(String userId) {
         getPreferencesEditor().putString(USER_ID_KEY, userId).commit();
     }
 

--- a/castle/src/main/java/io/castle/android/StorageHelper.java
+++ b/castle/src/main/java/io/castle/android/StorageHelper.java
@@ -15,6 +15,7 @@ class StorageHelper {
     private static final String VERSION_KEY = "version_key";
     private static final String USER_ID_KEY = "user_id_key";
     private static final String DEVICE_ID_KEY = "device_id_key";
+    private static final String SIGNATURE_KEY = "signature_key";
 
     private SharedPreferences preferences;
 
@@ -65,5 +66,13 @@ class StorageHelper {
 
     void setVersion(String version) {
         getPreferencesEditor().putString(VERSION_KEY, version).commit();
+    }
+
+    String getSignature() {
+        return getPreferences().getString(SIGNATURE_KEY, null);
+    }
+
+    void setSignature(String signature) {
+        getPreferencesEditor().putString(SIGNATURE_KEY, signature).commit();
     }
 }

--- a/castle/src/main/java/io/castle/android/StorageHelper.java
+++ b/castle/src/main/java/io/castle/android/StorageHelper.java
@@ -15,7 +15,7 @@ class StorageHelper {
     private static final String VERSION_KEY = "version_key";
     private static final String USER_ID_KEY = "user_id_key";
     private static final String DEVICE_ID_KEY = "device_id_key";
-    private static final String SIGNATURE_KEY = "signature_key";
+    private static final String USER_SIGNATURE_KEY = "user_signature_key";
 
     private SharedPreferences preferences;
 
@@ -68,11 +68,11 @@ class StorageHelper {
         getPreferencesEditor().putString(VERSION_KEY, version).commit();
     }
 
-    String getSignature() {
-        return getPreferences().getString(SIGNATURE_KEY, null);
+    String getUserSignature() {
+        return getPreferences().getString(USER_SIGNATURE_KEY, null);
     }
 
-    void setSignature(String signature) {
-        getPreferencesEditor().putString(SIGNATURE_KEY, signature).commit();
+    void setUserSignature(String signature) {
+        getPreferencesEditor().putString(USER_SIGNATURE_KEY, signature).commit();
     }
 }

--- a/castle/src/main/java/io/castle/android/Utils.java
+++ b/castle/src/main/java/io/castle/android/Utils.java
@@ -16,7 +16,6 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import io.castle.android.api.EventAdapter;
 import io.castle.android.api.model.Event;
 import io.castle.android.api.model.IdentifyEvent;
 import io.castle.android.api.model.ScreenEvent;

--- a/castle/src/main/java/io/castle/android/api/model/Event.java
+++ b/castle/src/main/java/io/castle/android/api/model/Event.java
@@ -16,9 +16,9 @@ import io.castle.android.Utils;
  * Model class for events
  */
 public class Event {
-    public static String EVENT_TYPE_EVENT = "track";
-    public static String EVENT_TYPE_SCREEN = "screen";
-    public static String EVENT_TYPE_IDENTIFY = "identify";
+    public static final String EVENT_TYPE_EVENT = "track";
+    public static final String EVENT_TYPE_SCREEN = "screen";
+    public static final String EVENT_TYPE_IDENTIFY = "identify";
 
     @SerializedName("context")
     Context context;
@@ -32,6 +32,8 @@ public class Event {
     String type;
     @SerializedName("user_id")
     String userId;
+    @SerializedName("signature")
+    String signature;
 
     /**
      * Create new event with specified name
@@ -43,6 +45,7 @@ public class Event {
         this.timestamp = Utils.getTimestamp();
         this.type = EVENT_TYPE_EVENT;
         this.userId = Castle.userId();
+        this.signature = Castle.signature();
     }
 
     /**

--- a/castle/src/main/java/io/castle/android/api/model/Event.java
+++ b/castle/src/main/java/io/castle/android/api/model/Event.java
@@ -32,8 +32,8 @@ public class Event {
     String type;
     @SerializedName("user_id")
     String userId;
-    @SerializedName("signature")
-    String signature;
+    @SerializedName("user_signature")
+    String userSignature;
 
     /**
      * Create new event with specified name
@@ -45,7 +45,7 @@ public class Event {
         this.timestamp = Utils.getTimestamp();
         this.type = EVENT_TYPE_EVENT;
         this.userId = Castle.userId();
-        this.signature = Castle.signature();
+        this.userSignature = Castle.userSignature();
     }
 
     /**

--- a/castle/src/test/java/io/castle/android/CastleConfigurationTest.java
+++ b/castle/src/test/java/io/castle/android/CastleConfigurationTest.java
@@ -97,6 +97,18 @@ public class CastleConfigurationTest {
         new StorageHelper(application).setBuild(0);
 
         Castle.configure(application);
+
+        // Destroy current instance
+        Castle.destroy(application);
+
+        // Try and set up SDK with new configuration while already configured
+        configuration = new CastleConfiguration.Builder()
+                .publishableKey("pk_SE5aTeotKZpDEn8kurzBYquRZyy21fvZ")
+                .build();
+
+        Castle.configure(application, "pk_123", configuration);
+
+        Assert.assertEquals("pk_123", Castle.publishableKey());
     }
 
     @After

--- a/castle/src/test/java/io/castle/android/CastleTest.java
+++ b/castle/src/test/java/io/castle/android/CastleTest.java
@@ -204,6 +204,15 @@ public class CastleTest {
 
     @Test
     public void testSecureMode() {
+
+        Castle.secure(null);
+
+        Assert.assertFalse(Castle.secureModeEnabled());
+
+        Castle.secure("");
+
+        Assert.assertFalse(Castle.secureModeEnabled());
+
         String signature = "944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52";
 
         Castle.secure(signature);

--- a/castle/src/test/java/io/castle/android/CastleTest.java
+++ b/castle/src/test/java/io/castle/android/CastleTest.java
@@ -79,6 +79,12 @@ public class CastleTest {
 
         // FlushIfNeeded returns true if url is whitelisted and flush() is called
         Assert.assertTrue(flushed);
+
+        // Make sure flush is NOT done for non whitelisted base url
+        flushed = Castle.flushIfNeeded("https://test.com");
+
+        // FlushIfNeeded returns fasle if url is not whitelisted
+        Assert.assertFalse(flushed);
     }
 
     @Test

--- a/castle/src/test/java/io/castle/android/CastleTest.java
+++ b/castle/src/test/java/io/castle/android/CastleTest.java
@@ -203,6 +203,11 @@ public class CastleTest {
     }
 
     @Test
+    public void testWhiteList() {
+        Assert.assertFalse(Castle.isUrlWhiteListed("invalid url"));
+    }
+
+    @Test
     public void testSecureMode() {
 
         Castle.secure(null);

--- a/castle/src/test/java/io/castle/android/CastleTest.java
+++ b/castle/src/test/java/io/castle/android/CastleTest.java
@@ -202,6 +202,15 @@ public class CastleTest {
         Assert.assertEquals(null, response.request().header(Castle.clientIdHeaderName));
     }
 
+    @Test
+    public void testSecureMode() {
+        String signature = "944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52";
+
+        Castle.secure(signature);
+
+        Assert.assertTrue(Castle.secureModeEnabled());
+    }
+
     @After
     public void after() {
         Castle.destroy(application);

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
     buildToolsVersion '28.0.3'
     defaultConfig {
-        applicationId "io.castle.android"
+        applicationId "io.castle.android.sample"
         minSdkVersion 15
         targetSdkVersion 28
         versionCode 1

--- a/example/src/main/java/io/castle/android/sample/MainActivity.java
+++ b/example/src/main/java/io/castle/android/sample/MainActivity.java
@@ -28,6 +28,9 @@ public class MainActivity extends AppCompatActivity {
 
     @OnClick(R.id.identify)
     public void onIdentifyClick(Button button) {
+        // Set signature for secure mode
+        Castle.secure("944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52");
+
         // Identify user with a unique identifier including user traits
         Map<String, String> traits = new HashMap<>();
         traits.put("email", "sebastian@boldsie.com");

--- a/gradle.properties.sample
+++ b/gradle.properties.sample
@@ -1,0 +1,5 @@
+android.enableUnitTestBinaryResources=true
+
+BINTRAY_USER=user
+BINTRAY_API_KEY=apikey
+BINTRAY_GPG_PASSWORD=password


### PR DESCRIPTION
This pull request adds support for secure mode.

A new method `secure` has been added to the public API. Calling this method will set the user signature and store it locally on the device. Here's an example:

```java
Castle.secure("944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52");
```

The signature will be included in all events sent from that point forward. Calling `reset` will clear any stored user signature and calling `secure` again will replace the current user signature.