### PR TITLE
Fix queue deserialize issue

### DIFF
--- a/castle/src/main/java/io/castle/android/queue/EventQueue.java
+++ b/castle/src/main/java/io/castle/android/queue/EventQueue.java
@@ -150,7 +150,7 @@ public class EventQueue implements Callback<Void> {
             CastleLogger.e(response.code() + " " + response.message());
             try {
                 CastleLogger.e("Batch request error:" + response.errorBody().string());
-            } catch (IOException e) {
+            } catch (Exception e) {
                 CastleLogger.e("Batch request error", e);
             }
         }

--- a/castle/src/main/java/io/castle/android/queue/EventQueue.java
+++ b/castle/src/main/java/io/castle/android/queue/EventQueue.java
@@ -27,6 +27,7 @@ import retrofit2.Response;
 
 public class EventQueue implements Callback<Void> {
     private static final String QUEUE_FILENAME = "castle-queue";
+    private static final int MAX_BATCH_SIZE = 100;
 
     private ObjectQueue<Event> eventObjectQueue;
 
@@ -84,8 +85,6 @@ public class EventQueue implements Callback<Void> {
         CastleLogger.d("EventQueue size " + eventObjectQueue.size());
         if (!isFlushing() && (!eventObjectQueue.isEmpty())) {
             trim();
-
-            List<Event> events = eventObjectQueue.peek(Castle.configuration().flushLimit());
 
             int end = Math.min(MAX_BATCH_SIZE, eventObjectQueue.size());
             List<Event> subList = new ArrayList<>(end);

--- a/castle/src/main/java/io/castle/android/queue/GsonConverter.java
+++ b/castle/src/main/java/io/castle/android/queue/GsonConverter.java
@@ -24,8 +24,13 @@ class GsonConverter<T> implements ObjectQueue.Converter<T> {
     }
 
     @Override public T from(byte[] bytes) {
-        Reader reader = new InputStreamReader(new ByteArrayInputStream(bytes));
-        return Utils.getGsonInstance().fromJson(reader, type);
+        try {
+            Reader reader = new InputStreamReader(new ByteArrayInputStream(bytes));
+            return Utils.getGsonInstance().fromJson(reader, type);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     @Override public void toStream(T object, OutputStream bytes) throws IOException {


### PR DESCRIPTION
If the JSON data for a queue entry is corrupted and therefore not valid, return null value in the converter and remove the item before sending the batch request.