### PR TITLE
Fix/timestamp format

### DIFF
--- a/castle/src/main/java/io/castle/android/Utils.java
+++ b/castle/src/main/java/io/castle/android/Utils.java
@@ -27,7 +27,7 @@ public class Utils {
 
     private static String formatDate(Date date) {
         if (formatter == null) {
-            formatter = new SimpleDateFormat(pattern, Locale.US);
+            formatter = new SimpleDateFormat(pattern, new Locale("en", "US", "POSIX"));
             formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
         }
         return formatter.format(date);


### PR DESCRIPTION
Use en_US_POSIX locale to make sure that dates are handled in the correct format 