### PR TITLE
Remove device name from event payload

### DIFF
--- a/castle/src/main/java/io/castle/android/api/model/Device.java
+++ b/castle/src/main/java/io/castle/android/api/model/Device.java
@@ -20,8 +20,6 @@ class Device {
     private String manufacturer;
     @SerializedName("model")
     private String model;
-    @SerializedName("name")
-    private String name;
     @SerializedName("type")
     private String type;
 
@@ -31,7 +29,6 @@ class Device {
         device.id = Castle.clientId();
         device.manufacturer = Build.MANUFACTURER;
         device.model = Build.MODEL;
-        device.name = Build.MODEL;
         device.type = Build.DEVICE;
 
         return device;


### PR DESCRIPTION
Remove the current device name from the device section of the event payload.