### PR TITLE
Remove core utils

### DIFF
--- a/castle/build.gradle
+++ b/castle/build.gradle
@@ -66,7 +66,6 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.10.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.9.1'
     implementation 'com.squareup.tape2:tape:2.0.0-beta1'
-    implementation 'com.android.support:support-core-utils:28.0.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'androidx.test:core:1.1.0'
     testImplementation 'androidx.test:rules:1.1.1'

--- a/castle/src/main/java/io/castle/android/api/model/Network.java
+++ b/castle/src/main/java/io/castle/android/api/model/Network.java
@@ -8,7 +8,6 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-import android.support.v4.content.PermissionChecker;
 import android.telephony.TelephonyManager;
 
 import com.google.gson.annotations.SerializedName;
@@ -16,10 +15,10 @@ import com.google.gson.annotations.SerializedName;
 import static android.Manifest.permission.ACCESS_NETWORK_STATE;
 import static android.content.Context.CONNECTIVITY_SERVICE;
 import static android.content.Context.TELEPHONY_SERVICE;
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 import static android.net.ConnectivityManager.TYPE_BLUETOOTH;
 import static android.net.ConnectivityManager.TYPE_MOBILE;
 import static android.net.ConnectivityManager.TYPE_WIFI;
-import static android.support.v4.content.PermissionChecker.PERMISSION_GRANTED;
 
 /**
  * Model class for network status, included in all events
@@ -36,7 +35,7 @@ public class Network {
 
     @SuppressLint("MissingPermission")
     private Network(Context context) {
-        if (PermissionChecker.checkCallingOrSelfPermission(context, ACCESS_NETWORK_STATE) == PERMISSION_GRANTED) {
+        if (context.checkCallingOrSelfPermission(ACCESS_NETWORK_STATE) == PERMISSION_GRANTED) {
             ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(CONNECTIVITY_SERVICE);
             if (connectivityManager != null) {
                 NetworkInfo wifiInfo = connectivityManager.getNetworkInfo(TYPE_WIFI);


### PR DESCRIPTION
Remove support-core-utils to make avoid any support library dependency issues when including the Castle SDK.