### PR TITLE
Fix queue error handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'org.jacoco:org.jacoco.core:0.8.3'
 

--- a/castle/bintray.gradle
+++ b/castle/bintray.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.dcendents.android-maven'
 
-def POM_VERSION = '1.1.1'
+def POM_VERSION = '1.1.2-SNAPSHOT'
 def POM_GROUP_ID = 'io.castle.android'
 def POM_ARTIFACT_ID = 'castle'
 def POM_DESCRIPTION = 'Android client library for Castle'

--- a/castle/build.gradle
+++ b/castle/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 28
         versionCode 1
-        versionName '1.1.1'
+        versionName '1.1.2-SNAPSHOT'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/castle/src/main/java/io/castle/android/queue/EventQueue.java
+++ b/castle/src/main/java/io/castle/android/queue/EventQueue.java
@@ -112,11 +112,12 @@ public class EventQueue implements Callback<Void> {
                 flushCall = CastleAPIService.getInstance().batch(batch);
                 flushCall.enqueue(this);
             } else {
-                CastleLogger.d("Did not flush EventQueue ");
+                CastleLogger.d("Did not flush EventQueue");
 
                 // If events is empty and end is greater than zero, we just have unreadable data in the queue
                 if (end > 0) {
                     eventObjectQueue.clear();
+                    CastleLogger.d("Clearing EventQueue because of unreadable data");
                 }
             }
         }

--- a/castle/src/main/java/io/castle/android/queue/EventQueue.java
+++ b/castle/src/main/java/io/castle/android/queue/EventQueue.java
@@ -90,9 +90,14 @@ public class EventQueue implements Callback<Void> {
             List<Event> subList = new ArrayList<>(end);
             Iterator<Event> iterator = eventObjectQueue.iterator();
             for (int i = 0; i < end; i++) {
-                Event event = iterator.next();
-                if (event != null) {
-                    subList.add(event);
+                try {
+                    Event event = iterator.next();
+
+                    if (event != null) {
+                        subList.add(event);
+                    }
+                } catch (Exception exception) {
+                    CastleLogger.e("Unable to read from queue", exception);
                 }
             }
             List<Event> events = Collections.unmodifiableList(subList);

--- a/castle/src/main/java/io/castle/android/queue/EventQueue.java
+++ b/castle/src/main/java/io/castle/android/queue/EventQueue.java
@@ -113,6 +113,11 @@ public class EventQueue implements Callback<Void> {
                 flushCall.enqueue(this);
             } else {
                 CastleLogger.d("Did not flush EventQueue ");
+
+                // If events is empty and end is greater than zero, we just have unreadable data in the queue
+                if (end > 0) {
+                    eventObjectQueue.clear();
+                }
             }
         }
     }

--- a/castle/src/main/java/io/castle/android/queue/EventQueue.java
+++ b/castle/src/main/java/io/castle/android/queue/EventQueue.java
@@ -152,6 +152,14 @@ public class EventQueue implements Callback<Void> {
                 CastleLogger.d("Removed " + flushCount + " events from EventQueue");
             } catch (IOException e) {
                 CastleLogger.e("Failed to remove events from queue", e);
+
+                try {
+                    CastleLogger.d("Clearing EventQueue");
+                    eventObjectQueue.clear();
+                } catch (IOException e1) {
+                    CastleLogger.d("Unable to clear EventQueue");
+                    e1.printStackTrace();
+                }
             }
 
             // Check if queue size still exceed the flush limit and if it does, flush.

--- a/castle/src/main/java/io/castle/android/queue/EventQueue.java
+++ b/castle/src/main/java/io/castle/android/queue/EventQueue.java
@@ -96,6 +96,8 @@ public class EventQueue implements Callback<Void> {
                     }
                 } catch (Exception exception) {
                     CastleLogger.e("Unable to read from queue", exception);
+                } catch (Error error) {
+                    CastleLogger.e("Unable to read from queue", error);
                 }
             }
             List<Event> events = Collections.unmodifiableList(subList);

--- a/castle/src/test/AndroidManifest.xml
+++ b/castle/src/test/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.castle.android"
     android:versionCode="1"
-    android:versionName="1.0"
+    android:versionName="1.1.2-SNAPSHOT"
     android:label="Castle">
 
     <uses-permission android:name="android.permission.INTERNET" />

--- a/castle/src/test/java/io/castle/android/CastleTest.java
+++ b/castle/src/test/java/io/castle/android/CastleTest.java
@@ -237,7 +237,7 @@ public class CastleTest {
     @Test
     @Config(manifest = "AndroidManifest.xml")
     public void testUserAgent() {
-        String regex = "[a-zA-Z0-9\\s._-]+/[0-9]+\\.[0-9]+\\.?[0-9]* \\([a-zA-Z0-9-_.]+\\) \\([a-zA-Z0-9\\s]+; Android [0-9]+\\.?[0-9]*; Castle [0-9]+\\.[0-9]+\\.?[0-9]*(-SNAPSHOT)*\\)";
+        String regex = "[a-zA-Z0-9\\s._-]+/[0-9]+\\.[0-9]+\\.?[0-9]* \\([a-zA-Z0-9-_.]+\\) \\([a-zA-Z0-9\\s]+; Android [0-9]+\\.?[0-9]*; Castle [0-9]+\\.[0-9]+\\.?[0-9]*[a-zA-Z-]*\\)";
 
         Pattern pattern = Pattern.compile(regex);
 

--- a/castle/src/test/java/io/castle/android/CastleTest.java
+++ b/castle/src/test/java/io/castle/android/CastleTest.java
@@ -237,7 +237,7 @@ public class CastleTest {
     @Test
     @Config(manifest = "AndroidManifest.xml")
     public void testUserAgent() {
-        String regex = "[a-zA-Z0-9\\s._-]+/[0-9]+\\.[0-9]+\\.?[0-9]* \\([a-zA-Z0-9-_.]+\\) \\([a-zA-Z0-9\\s]+; Android [0-9]+\\.?[0-9]*; Castle [0-9]+\\.[0-9]+\\.?[0-9]*\\)";
+        String regex = "[a-zA-Z0-9\\s._-]+/[0-9]+\\.[0-9]+\\.?[0-9]* \\([a-zA-Z0-9-_.]+\\) \\([a-zA-Z0-9\\s]+; Android [0-9]+\\.?[0-9]*; Castle [0-9]+\\.[0-9]+\\.?[0-9]*(-SNAPSHOT)*\\)";
 
         Pattern pattern = Pattern.compile(regex);
 

--- a/castle/src/test/java/io/castle/android/CastleTest.java
+++ b/castle/src/test/java/io/castle/android/CastleTest.java
@@ -237,13 +237,15 @@ public class CastleTest {
     @Test
     @Config(manifest = "AndroidManifest.xml")
     public void testUserAgent() {
-        String regex = "[a-zA-Z0-9\\s._-]+/[0-9]+\\.[0-9]+\\.?[0-9]* \\([a-zA-Z0-9-_.]+\\) \\([a-zA-Z0-9\\s]+; Android [0-9]+\\.?[0-9]*; Castle [0-9]+\\.[0-9]+\\.?[0-9]*[a-zA-Z-]*\\)";
+        String regex = "[a-zA-Z0-9\\s._-]+/[0-9]+\\.[0-9]+\\.?[0-9]*(-[a-zA-Z0-9]*)? \\([a-zA-Z0-9-_.]+\\) \\([a-zA-Z0-9\\s]+; Android [0-9]+\\.?[0-9]*; Castle [0-9]+\\.[0-9]+\\.?[0-9]*(-[a-zA-Z0-9]*)?\\)";
 
         Pattern pattern = Pattern.compile(regex);
 
         Matcher matcher = pattern.matcher(Castle.userAgent());
 
         Assert.assertTrue(matcher.matches());
+
+        
     }
 
     @After

--- a/castle/src/test/java/io/castle/android/CastleTest.java
+++ b/castle/src/test/java/io/castle/android/CastleTest.java
@@ -245,7 +245,13 @@ public class CastleTest {
 
         Assert.assertTrue(matcher.matches());
 
-        
+        matcher = pattern.matcher("io.castle.android.test/1.0 (1) (Google Nexus 5x; Android 9.0; Castle 1.1.1)");
+
+        Assert.assertTrue(matcher.matches());
+
+        matcher = pattern.matcher("io.castle.android.test/1.0-SNAPSHOT (1) (Google Nexus 5x; Android 9.0; Castle 1.1.1-SNAPSHOT)");
+
+        Assert.assertTrue(matcher.matches());
     }
 
     @After


### PR DESCRIPTION
Add improved error handling when queue is corrupted. If a problem is encountered reading an item from the queue, skip that item. If there is a problem removing items from the queue we reset the queue.