### PR TITLE
Handle activity with no title set in screen tracking

### DIFF
--- a/castle/src/main/java/io/castle/android/api/model/ScreenEvent.java
+++ b/castle/src/main/java/io/castle/android/api/model/ScreenEvent.java
@@ -27,6 +27,6 @@ public class ScreenEvent extends Event {
      * @param activity Activity
      */
     public ScreenEvent(Activity activity) {
-        this(activity.getTitle().toString());
+        this(activity.getTitle() != null ? activity.getTitle().toString() : activity.getClass().getSimpleName());
     }
 }

--- a/castle/src/test/java/io/castle/android/CastleTest.java
+++ b/castle/src/test/java/io/castle/android/CastleTest.java
@@ -46,6 +46,8 @@ public class CastleTest {
     public void setup() {
         application = rule.getActivity().getApplication();
 
+        rule.getActivity().setTitle("TestActivityTitle");
+
         ArrayList<String> baseUrlWhiteList = new ArrayList<>();
         baseUrlWhiteList.add("https://google.com/");
 
@@ -131,6 +133,17 @@ public class CastleTest {
 
         ScreenEvent screenEvent = new ScreenEvent("Main");
         Assert.assertEquals(screenEvent.getEvent(), "Main");
+        Assert.assertEquals(screenEvent.getType(), Event.EVENT_TYPE_SCREEN);
+
+        screenEvent = new ScreenEvent(rule.getActivity());
+        Assert.assertEquals(screenEvent.getEvent(), "TestActivityTitle");
+        Assert.assertEquals(screenEvent.getType(), Event.EVENT_TYPE_SCREEN);
+
+        // Test null activity title
+        rule.getActivity().setTitle(null);
+
+        screenEvent = new ScreenEvent(rule.getActivity());
+        Assert.assertEquals(screenEvent.getEvent(), "TestActivity");
         Assert.assertEquals(screenEvent.getType(), Event.EVENT_TYPE_SCREEN);
 
         count = Castle.queueSize();


### PR DESCRIPTION
Fallback to class name if supplied activity has no title set.

Close #26 