### PR TITLE
Fix code coverage issue after added size stats

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,4 +35,4 @@ jobs:
       - store_test_results:
           path: castle/build/test-results
       - codecov/upload:
-          file: castle/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
+          file: castle/build/reports/jacoco/jacocoTestDebugUnitTestReport/jacocoTestDebugUnitTestReport.xml

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'org.jacoco:org.jacoco.core:0.8.3'
+        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.6'
         classpath 'com.vanniktech:gradle-android-apk-size-plugin:0.4.0'
 

--- a/castle/build.gradle
+++ b/castle/build.gradle
@@ -1,7 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'jacoco'
-apply plugin: 'com.getkeepsafe.dexcount'
-apply plugin: 'com.vanniktech.android.apk.size'
 
 jacoco {
     toolVersion = '0.8.3'
@@ -81,6 +79,7 @@ dependencies {
 
 if (!ciBuild) {
     apply from: 'bintray.gradle'
+    apply from: 'size.gradle'
 }
 
 task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
@@ -91,52 +90,12 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'crea
     }
 
     def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
-    def debugTree = fileTree(dir: "$project.buildDir/intermediates/javac/debug/compileDebugJavaWithJavac/classes", excludes: fileFilter)
+    def debugTree = fileTree(dir: "$project.buildDir/intermediates/classes/debug", excludes: fileFilter)
     def mainSrc = "$project.projectDir/src/main/java"
 
     sourceDirectories = files([mainSrc])
     classDirectories = files([debugTree])
     executionData = fileTree(dir: project.buildDir, includes: [
-            'jacoco/testDebugUnitTest.exec', 'outputs/code_coverage/debugAndroidTest/connected/*coverage.ec'
+            'jacoco/testDebugUnitTest.exec', 'outputs/code-coverage/connected/*coverage.ec'
     ])
-}
-
-tasks.create("depsize-all-configurations") {
-    doLast {
-        configurations.each {
-            if (it.isCanBeResolved()) {
-                listConfigurationDependencies(it)
-            }
-        }
-    }
-}
-
-tasks.create("depsize") {
-    doLast {
-        listConfigurationDependencies(configurations.getByName('releaseRuntimeClasspath'))
-    }
-}
-
-task('size', dependsOn: ['clean', 'assembleRelease', 'countReleaseDexMethods', 'depsize'])
-
-def listConfigurationDependencies(Configuration configuration) {
-    def formatStr = "%,10.2f"
-
-    def size = configuration.collect { it.length() / (1024 * 1024) }.sum()
-
-    def out = new StringBuffer()
-    out << "\nConfiguration name: \"${configuration.name}\"\n"
-    if (size) {
-        out << 'Total dependencies size:'.padRight(65)
-        out << "${String.format(formatStr, size)} Mb\n\n"
-
-        configuration.sort { -it.length() }
-                .each {
-            out << "${it.name}".padRight(65)
-            out << "${String.format(formatStr, (it.length() / 1024))} kb\n"
-        }
-    } else {
-        out << 'No dependencies found'
-    }
-    println(out)
 }

--- a/castle/build.gradle
+++ b/castle/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
-apply plugin: 'jacoco'
+apply plugin: 'jacoco-android'
 
 jacoco {
-    toolVersion = '0.8.3'
+    toolVersion = "0.8.4"
 }
 
 tasks.withType(Test) {
@@ -80,22 +80,4 @@ dependencies {
 if (!ciBuild) {
     apply from: 'bintray.gradle'
     apply from: 'size.gradle'
-}
-
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
-
-    reports {
-        xml.enabled = true
-        html.enabled = true
-    }
-
-    def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
-    def debugTree = fileTree(dir: "$project.buildDir/intermediates/classes/debug", excludes: fileFilter)
-    def mainSrc = "$project.projectDir/src/main/java"
-
-    sourceDirectories = files([mainSrc])
-    classDirectories = files([debugTree])
-    executionData = fileTree(dir: project.buildDir, includes: [
-            'jacoco/testDebugUnitTest.exec', 'outputs/code-coverage/connected/*coverage.ec'
-    ])
 }

--- a/castle/size.gradle
+++ b/castle/size.gradle
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020 Castle
+ */
+
+apply plugin: 'com.getkeepsafe.dexcount'
+apply plugin: 'com.vanniktech.android.apk.size'
+
+tasks.create("depsize-all-configurations") {
+    doLast {
+        configurations.each {
+            if (it.isCanBeResolved()) {
+                listConfigurationDependencies(it)
+            }
+        }
+    }
+}
+
+tasks.create("depsize") {
+    doLast {
+        listConfigurationDependencies(configurations.getByName('releaseRuntimeClasspath'))
+    }
+}
+
+task('size', dependsOn: ['clean', 'assembleRelease', 'countReleaseDexMethods', 'depsize'])
+
+def listConfigurationDependencies(Configuration configuration) {
+    def formatStr = "%,10.2f"
+
+    def size = configuration.collect { it.length() / (1024 * 1024) }.sum()
+
+    def out = new StringBuffer()
+    out << "\nConfiguration name: \"${configuration.name}\"\n"
+    if (size) {
+        out << 'Total dependencies size:'.padRight(65)
+        out << "${String.format(formatStr, size)} Mb\n\n"
+
+        configuration.sort { -it.length() }
+                .each {
+                    out << "${it.name}".padRight(65)
+                    out << "${String.format(formatStr, (it.length() / 1024))} kb\n"
+                }
+    } else {
+        out << 'No dependencies found'
+    }
+    println(out)
+}


### PR DESCRIPTION
Add size related gradle tasks and plugins in a separate gradle file and only include it in non ci builds to ensure that the code coverage works as expected.