### PR TITLE
Add try catch for NPE being thrown when deserializing queue

### DIFF
--- a/castle/src/main/java/io/castle/android/queue/EventQueue.java
+++ b/castle/src/main/java/io/castle/android/queue/EventQueue.java
@@ -109,7 +109,13 @@ public class EventQueue implements Callback<Void> {
                 CastleLogger.d("Flushing EventQueue " + end);
 
                 flushCount = end;
-                flushCall = CastleAPIService.getInstance().batch(batch);
+                try {
+                    flushCall = CastleAPIService.getInstance().batch(batch);
+                } catch (NullPointerException npe) {
+                    // Band aid for https://github.com/castle/castle-android/issues/37
+                    CastleLogger.d("Did not flush EventQueue because NPE, clearing EventQueue");
+                    eventObjectQueue.clear();
+                }
                 flushCall.enqueue(this);
             } else {
                 CastleLogger.d("Did not flush EventQueue");


### PR DESCRIPTION
Prevent crash because of issue #37 