### PR TITLE
Run lifecycle event tracking and flush off the main thread

### DIFF
--- a/castle/src/main/java/io/castle/android/Castle.java
+++ b/castle/src/main/java/io/castle/android/Castle.java
@@ -18,15 +18,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import io.castle.android.api.model.CustomEvent;
 import io.castle.android.api.model.Event;
 import io.castle.android.api.model.ScreenEvent;
 import io.castle.android.api.model.UserJwt;
 import io.castle.highwind.android.Highwind;
-import io.castle.android.queue.EventQueue;
 
 /**
  * This class is the main entry point for using the Castle SDK and provides methods for tracking events, screen views, manual flushing of the event queue, allowlisting behaviour and resetting.
@@ -90,30 +87,30 @@ public class Castle {
         activityLifecycleCallbacks = new CastleActivityLifecycleCallbacks();
         application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks);
 
-        // Build the install/update/opened events off the main thread
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        executor.execute(() -> {
-            int previousBuild = storageHelper.getBuild();
+        // Get the previous recorded version.
+        int previousBuild = storageHelper.getBuild();
 
-            if (previousBuild == -1) {
-                trackLifeCycleEvent("Application Installed");
-            } else if (appBuild != previousBuild) {
-                trackLifeCycleEvent("Application Updated");
-            }
+        // Check and track Application Installed or Application Updated.
+        if (previousBuild == -1) {
+            trackLifeCycleEvent("Application Installed");
+        } else if (appBuild != previousBuild) {
+            trackLifeCycleEvent("Application Updated");
+        }
 
-            trackLifeCycleEvent("Application Opened");
+        // Track Application Opened.
+        trackLifeCycleEvent("Application Opened");
 
-            flush();
+        flush();
 
-            storageHelper.setVersion(appVersion);
-            storageHelper.setBuild(appBuild);
-        });
-        executor.shutdown();
+        // Update the recorded version.
+        storageHelper.setVersion(appVersion);
+        storageHelper.setBuild(appBuild);
     }
 
     static void trackLifeCycleEvent(String event) {
         if (Castle.configuration().applicationLifecycleTrackingEnabled()) {
-            custom(event);
+            EventQueue queue = getInstance().eventQueue;
+            queue.execute(() -> queue.addImmediate(new CustomEvent(event)));
         }
     }
 

--- a/castle/src/main/java/io/castle/android/Castle.java
+++ b/castle/src/main/java/io/castle/android/Castle.java
@@ -18,6 +18,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import io.castle.android.api.model.CustomEvent;
 import io.castle.android.api.model.Event;
@@ -88,24 +90,25 @@ public class Castle {
         activityLifecycleCallbacks = new CastleActivityLifecycleCallbacks();
         application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks);
 
-        // Get the previous recorded version.
-        int previousBuild = storageHelper.getBuild();
+        // Build the install/update/opened events off the main thread
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        executor.execute(() -> {
+            int previousBuild = storageHelper.getBuild();
 
-        // Check and track Application Installed or Application Updated.
-        if (previousBuild == -1) {
-            trackLifeCycleEvent("Application Installed");
-        } else if (appBuild != previousBuild) {
-            trackLifeCycleEvent("Application Updated");
-        }
+            if (previousBuild == -1) {
+                trackLifeCycleEvent("Application Installed");
+            } else if (appBuild != previousBuild) {
+                trackLifeCycleEvent("Application Updated");
+            }
 
-        // Track Application Opened.
-        trackLifeCycleEvent("Application Opened");
+            trackLifeCycleEvent("Application Opened");
 
-        flush();
+            flush();
 
-        // Update the recorded version.
-        storageHelper.setVersion(appVersion);
-        storageHelper.setBuild(appBuild);
+            storageHelper.setVersion(appVersion);
+            storageHelper.setBuild(appBuild);
+        });
+        executor.shutdown();
     }
 
     static void trackLifeCycleEvent(String event) {

--- a/castle/src/main/java/io/castle/android/EventQueue.java
+++ b/castle/src/main/java/io/castle/android/EventQueue.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2020 Castle
  */
 
-package io.castle.android.queue;
+package io.castle.android;
 
 import android.content.Context;
 
@@ -18,9 +18,6 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import io.castle.android.Castle;
-import io.castle.android.CastleLogger;
-import io.castle.android.Utils;
 import io.castle.android.api.CastleAPIService;
 import io.castle.android.api.model.Event;
 import io.castle.android.api.model.Monitor;
@@ -84,18 +81,28 @@ public class EventQueue implements Callback<Void> {
     }
 
     public synchronized void add(Event event) {
-        executor.execute(() -> {
-            try {
-                CastleLogger.d("Tracking event " + Utils.getGsonInstance().toJson(event));
-                eventObjectQueue.add(event);
+        executor.execute(() -> addImmediate(event));
+    }
 
-                if (needsFlush()) {
-                    flush();
-                }
-            } catch (IOException e) {
-                CastleLogger.e("Add to queue failed", e);
+    /**
+     * Add an event synchronously. Must only be called from a Runnable submitted via
+     * {@link #execute(Runnable)} so that ordering is preserved with {@link #add(Event)}.
+     */
+    void addImmediate(Event event) {
+        try {
+            CastleLogger.d("Tracking event " + Utils.getGsonInstance().toJson(event));
+            eventObjectQueue.add(event);
+
+            if (needsFlush()) {
+                flush();
             }
-        });
+        } catch (IOException e) {
+            CastleLogger.e("Add to queue failed", e);
+        }
+    }
+
+    void execute(Runnable runnable) {
+        executor.execute(runnable);
     }
 
     private synchronized void trim() throws IOException {

--- a/castle/src/main/java/io/castle/android/GsonConverter.java
+++ b/castle/src/main/java/io/castle/android/GsonConverter.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2020 Castle
  */
 
-package io.castle.android.queue;
+package io.castle.android;
 
 import com.squareup.tape2.ObjectQueue;
 
@@ -13,8 +13,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
-
-import io.castle.android.Utils;
 
 class GsonConverter<T> implements ObjectQueue.Converter<T> {
     private final Class<T> type;

--- a/castle/src/test/java/io/castle/android/CastleTest.java
+++ b/castle/src/test/java/io/castle/android/CastleTest.java
@@ -6,6 +6,7 @@ package io.castle.android;
 
 import static org.awaitility.Awaitility.await;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import android.Manifest;
@@ -27,6 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -87,6 +89,14 @@ public class CastleTest {
                 .screenTrackingEnabled(true)
                 .baseURLAllowList(baseURLAllowList)
                 .build());
+
+        // Wait for lifecycle events submitted by configure() to settle so each test
+        // starts from a deterministic queue state.
+        AtomicInteger last = new AtomicInteger(-1);
+        await().pollInterval(50, MILLISECONDS).atMost(5, SECONDS).until(() -> {
+            int now = Castle.queueSize();
+            return now == last.getAndSet(now);
+        });
 
         client = new OkHttpClient.Builder()
                 .addInterceptor(Castle.castleInterceptor())


### PR DESCRIPTION
Move the install/update/opened lifecycle event tracking and the subsequent flush into a single-thread executor so SDK configure no longer blocks the application's main thread on first launch.